### PR TITLE
made exit message more obvious and verbose

### DIFF
--- a/archlinux_2015_12_01/archinstall.sh
+++ b/archlinux_2015_12_01/archinstall.sh
@@ -35,6 +35,8 @@ mount --rbind /run /mnt/run
 
 chroot /mnt/ /opt/install/archinstall_finalize
 
+echo "~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~"
 echo "finished"
+echo "********"
 
 #rm -r /mnt/opt/install


### PR DESCRIPTION
To ensure users are easily able to see the exit message, the echo message has been replaced with 

```
echo "~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~"
echo "finished"
echo "********"
```

resulting in

```
~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~
finished
********
```
